### PR TITLE
Fix keys count

### DIFF
--- a/bin/ssh-ldap-pubkey-wrapper
+++ b/bin/ssh-ldap-pubkey-wrapper
@@ -7,7 +7,7 @@
 SSH_USER="$1"
 
 KEYS="`ssh-ldap-pubkey list -q -u "$SSH_USER"`"
-KEYS_COUNT=`echo "$KEYS" | wc -l`
+KEYS_COUNT=`echo "$KEYS" | grep '^ssh' | wc -l`
 
 logger -i -t sshd -p info \
     "Loaded ${KEYS_COUNT} SSH public key(s) from LDAP for user: ${SSH_USER}"


### PR DESCRIPTION
If a user does not have a public key, the script incorrectly returns 1 loaded public key instead of 0.