### PR TITLE
Moved the kwargs statement, so you can use this as a module

### DIFF
--- a/bin/ssh-ldap-pubkey
+++ b/bin/ssh-ldap-pubkey
@@ -359,8 +359,6 @@ def main(**kwargs):
     finally:
         ls.close()
 
-
-kwargs = docopt(__doc__, version="ssh-ldap-pubkey %s" % __version__)
-
 if __name__ == '__main__':
+    kwargs = docopt(__doc__, version="ssh-ldap-pubkey %s" % __version__)
     main(**kwargs)


### PR DESCRIPTION
Moved the kwargs statement so you can use the ssh-ldap-pubkey as a module.