### PR TITLE
Added support to change the TLS_REQCERT option

### DIFF
--- a/bin/ssh-ldap-pubkey
+++ b/bin/ssh-ldap-pubkey
@@ -77,6 +77,7 @@ class LdapSSH(object):
         if not conf.uri or not conf.base:
             raise ConfigError("Base DN and LDAP URI must be provided.", 1)
 
+        ldap.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, conf.tls_required)
         if conf.cacert_dir:
             # this is a global option!
             ldap.set_option(ldap.OPT_X_TLS_CACERTDIR, conf.cacert_dir)
@@ -205,6 +206,14 @@ class LdapConfig(object):
         self.login_attr = conf.get('pam_login_attribute', DEFAULT_LOGIN_ATTR)
         self.filter = conf.get('pam_filter', DEFAULT_FILTER)
         self.cacert_dir = conf.get('tls_cacertdir', None)
+
+        self.tls_required = {
+            'never': ldap.OPT_X_TLS_NEVER,
+            'allow': ldap.OPT_X_TLS_ALLOW,
+            'try': ldap.OPT_X_TLS_TRY,
+            'demand': ldap.OPT_X_TLS_DEMAND,
+            'hard': ldap.OPT_X_TLS_HARD
+        }[conf.get('tls_reqcert', 'demand')]
 
         self.scope = {
             'base': ldap.SCOPE_BASE,


### PR DESCRIPTION
Sometimes during development you are not interested in the certificate validation. Default value for TLS_REQCERT is demand.