### PR TITLE
Added support for 'ssl starttls' in /etc/ldap.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ parameters are used:
 *  **binddn** ... distinguished name (DN) to bind when reading the user’s entry (default is to bind
                   anonymously).
 *  **bindpw** ... credentials to bind with when reading the user’s entry (default is none).
-*  **ssl** ... does the LDAP server require starttls
+*  **ssl** ... LDAP SSL mechanism (off, on, start_tls)
 *  **timelimit** ... search time limit in seconds (default is 10).
 *  **bind_timelimit** ... bind/connect time limit in seconds (default is 10).
 *  **tls_cacertdir** ... path of the directory with CA certificates for LDAP server certificate

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ parameters are used:
 *  **binddn** ... distinguished name (DN) to bind when reading the user’s entry (default is to bind
                   anonymously).
 *  **bindpw** ... credentials to bind with when reading the user’s entry (default is none).
+*  **ssl** ... does the LDAP server require starttls
 *  **timelimit** ... search time limit in seconds (default is 10).
 *  **bind_timelimit** ... bind/connect time limit in seconds (default is 10).
 *  **tls_cacertdir** ... path of the directory with CA certificates for LDAP server certificate

--- a/ssh_ldap_pubkey/__init__.py
+++ b/ssh_ldap_pubkey/__init__.py
@@ -84,7 +84,7 @@ class LdapSSH(object):
             conn.network_timeout = conf.bind_timeout
             conn.timeout = conf.search_timeout
 
-            if conf.ssl == 'start_tls' and conf.uri.startswith('ldap://'):
+            if conf.ssl == 'start_tls' and conf.ldap_version >= 3:
                 conn.start_tls_s()
 
             if conf.bind_dn and conf.bind_pass:

--- a/ssh_ldap_pubkey/__init__.py
+++ b/ssh_ldap_pubkey/__init__.py
@@ -84,6 +84,9 @@ class LdapSSH(object):
             conn.network_timeout = conf.bind_timeout
             conn.timeout = conf.search_timeout
 
+            if conf.ssl == 'start_tls' and conf.uri.startswith('ldap://'):
+                conn.start_tls_s()
+
             if conf.bind_dn and conf.bind_pass:
                 self._bind(conf.bind_dn, conf.bind_pass)
         except ldap.SERVER_DOWN:

--- a/ssh_ldap_pubkey/config.py
+++ b/ssh_ldap_pubkey/config.py
@@ -80,6 +80,7 @@ class LdapConfig(object):
         self.base = conf.get('nss_base_passwd', '').split('?')[0] or conf.get('base', None)
         self.bind_dn = conf.get('binddn', None)
         self.bind_pass = conf.get('bindpw', None)
+        self.ssl = conf.get('ssl', None)
         self.ldap_version = int(conf.get('ldap_version', ldap.VERSION3))
         self.bind_timeout = int(conf.get('bind_timelimit', DEFAULT_TIMEOUT))
         self.search_timeout = int(conf.get('timelimit', DEFAULT_TIMEOUT))


### PR DESCRIPTION
Will now perform StartTLS on connecting to the LDAP server if specified in /etc/ldap.conf.

Previously used to fail if TLS was required when connecting via an ldap:// URI