### PR TITLE
Fix Complex filters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 sudo: false
 python:
   - 2.7
-  - 3.3
   - 3.4
   - 3.5
   - 3.6

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ or [this one](https://gist.github.com/jirutka/b15c31b2739a4f3eab63) written in P
 Requirements
 ------------
 
-* Python 3.3+ or 2.7+
+* Python 3.4+ or 2.7+
 * [pyldap] \(or [python-ldap])
 * [docopt]
 

--- a/ssh_ldap_pubkey/config.py
+++ b/ssh_ldap_pubkey/config.py
@@ -28,9 +28,9 @@ def parse_config(content):
         dict: Parsed options.
     """
     return {
-        match.group(1).lower(): match.group(2)
+        match.group(1).lower(): match.group(2).strip()
         for match in (
-            re.match(r'^(\w+)\s+([^#]+\b)', line)
+            re.match(r'^(\w+)\s+([^#]+)', line)
             for line in content.splitlines()
         ) if match
     }

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -58,11 +58,25 @@ def describe_parse_config():
 def describe_parse_config_file():
 
     def reads_file_and_calls_parse_config(mocker):
-        content = u'scope one\ntimelimit 3\n'
+        import inspect
+        # This removes the leading whitespace in this file for the test.
+        content = inspect.cleandoc(u'''
+        scope one
+        timelimit 3
+        pam_filter (objectclass=posixAccount)
+        nss_reconnect_tries 2 # number of times to double the sleep time
+        trailing_space_after_variable foobar    
+        ''')  # noqa
         open_func = 'builtins.open' if PY3 else '__builtin__.open'
         open_mock = mocker.patch(open_func, return_value=StringIO(initial_value=content))
 
-        result = {'scope': 'one', 'timelimit': '3'}
+        result = {
+            'scope': 'one',
+            'timelimit': '3',
+            'pam_filter': '(objectclass=posixAccount)',
+            'nss_reconnect_tries': '2',
+            'trailing_space_after_variable': 'foobar',
+        }
         parse_config_mock = mocker.patch('ssh_ldap_pubkey.config.parse_config', return_value=result)
 
         assert parse_config_file('/etc/ldap.conf') == result


### PR DESCRIPTION
Complex LDAP search filters used in `pam_filter` break both the config parser & the filter builder. This PR fixes them :-).