### PR TITLE
Fix tls_reqcert value of never to be accepted when defined.

### DIFF
--- a/ssh_ldap_pubkey/__init__.py
+++ b/ssh_ldap_pubkey/__init__.py
@@ -86,7 +86,7 @@ class LdapSSH(object):
         if not conf.uris or not conf.base:
             raise ConfigError('Base DN and LDAP URI(s) must be provided.', 1)
 
-        if conf.tls_require_cert:
+        if conf.tls_require_cert is not None:
             if conf.tls_require_cert not in [ldap.OPT_X_TLS_DEMAND, ldap.OPT_X_TLS_HARD]:
                 print(BAD_REQCERT_WARNING, file=sys.stderr)
             # this is a global option!


### PR DESCRIPTION
When the tls_reqcert value is set to `never` it is ignored in connect since
LDAP_OPT_X_TLS_NEVER evaluates to 0 which in turn gets evaluated to
False and the block is skipped.  I assume this is just a long standing
bug and not intended.  If the user is specifically saying they do not
care about certificate validation I would expect this to be allowed.
This commit will always set the validation settings for certificates if
the user has specified any value for tls_reqcert in the configuration.
If no value is specificed in the configuration then it continues to work
as it currently does (with default values).