### PR TITLE
Use keys in ~/.ssh/authorized_keys in addition to LDAP

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ OpenSSH / LDAP public keys
 [![version](https://img.shields.io/pypi/v/ssh-ldap-pubkey.svg?style=flat)](https://pypi.python.org/pypi/ssh-ldap-pubkey)
 
 This project provides an utility to manage SSH public keys stored in LDAP and also a script for
-OpenSSH server to load authorized keys from LDAP.
+OpenSSH server to load authorized keys from LDAP, in addition to those in `~/.ssh/authorized_keys`.
 
 
 Why?

--- a/bin/ssh-ldap-pubkey-wrapper
+++ b/bin/ssh-ldap-pubkey-wrapper
@@ -2,14 +2,29 @@
 #
 # Wrapper script for ssh-ldap-pubkey to be used as AuthorizedKeysCommand
 # in OpenSSHd.
+#
+# It will also look for keys in ~/.ssh/authorized_keys
 set -eu
 
 SSH_USER="$1"
+
+SSH_USER_KEY_FILE="$(eval echo ~"$1")/.ssh/authorized_keys"
+if [ -f "$SSH_USER_KEY_FILE" ]; then
+    SSH_USER_KEY_FILE_KEYS=$(<$SSH_USER_KEY_FILE)
+    KEY_FILE_KEYS_COUNT="$(printf '%s\n' "$KEYS" | grep 'ssh-' | wc -l)"
+else
+    SSH_USER_KEY_FILE_KEYS=""
+    KEY_FILE_KEYS_COUNT="0"
+fi
 
 KEYS="$(ssh-ldap-pubkey list -q -u "$SSH_USER")"
 KEYS_COUNT="$(printf '%s\n' "$KEYS" | grep '^ssh' | wc -l)"
 
 logger -t sshd -p info \
-	"Loaded ${KEYS_COUNT} SSH public key(s) from LDAP for user: ${SSH_USER}"
+	"Loaded ${KEY_FILE_KEYS_COUNT} SSH public key(s) from authorized_keys file for user: ${SSH_USER}"
+logger -t sshd -p info \
+        "Loaded ${KEYS_COUNT} SSH public key(s) from LDAP for user: ${SSH_USER}"
 
+
+printf '%s\n' "$SSH_USER_KEY_FILE_KEYS"
 printf '%s\n' "$KEYS"


### PR DESCRIPTION
I've been making use of `borg` recently, and the recommended way is to use `~/.ssh/authorized_keys` to restrict the use of an SSH key to one command.

This pull allows users to still make use of this by modifying `ssh-ldap-pubkey-wrapper` to first printing the contents of `~/.ssh/authorized_keys` and then any keys stored in LDAP.